### PR TITLE
Cut track titles after 128 charcters

### DIFF
--- a/src/main/java/rocks/voss/spotifytonieboxsync/Application.java
+++ b/src/main/java/rocks/voss/spotifytonieboxsync/Application.java
@@ -238,6 +238,10 @@ class Application {
         trackTitle = StringUtils.replace(trackTitle, "%d", String.valueOf(track.getTrack().getDiscNumber()));
         trackTitle = StringUtils.replace(trackTitle, "%t", String.valueOf(track.getTrack().getTrackNumber()));
 
+        /*The maximum chapter length is 128 characters. Note that this might result in the unlikely failure
+        to delete the track automatically if the second "-" character is cut away.*/
+        trackTitle = StringUtils.left(trackTitle, 128);
+
         log.debug(trackTitle);
         return trackTitle;
     }


### PR DESCRIPTION
Commit to the tonie fails when the track length exeecd 128 characters. To fix this we simply cut after 128 characters. If the track title on spotify is really long we might loose the ability to automatically delete the file (in case the second ' - ' would be cut aways. Since this is very unlikely we simply live with that.